### PR TITLE
Add initial support for scn-editor agents

### DIFF
--- a/scn-redactor/.vscode/launch.json
+++ b/scn-redactor/.vscode/launch.json
@@ -10,6 +10,15 @@
       "url": "http://localhost:4200/"
     },
     {
+      "name": "ng serve (Firefox)",
+      "type": "firefox",
+      "request": "launch",
+      "reAttach": true,
+      "preLaunchTask": "npm: start",
+      "url": "http://localhost:4200/",
+      "webRoot": "${workspaceFolder}"
+    },
+    {
       "name": "ng test",
       "type": "chrome",
       "request": "launch",

--- a/scn-redactor/package-lock.json
+++ b/scn-redactor/package-lock.json
@@ -19,6 +19,7 @@
         "@angular/platform-browser-dynamic": "^16.2.12",
         "@angular/router": "^16.2.12",
         "rxjs": "~7.8.0",
+        "ts-sc-client": "^0.4.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.13.3"
       },
@@ -12802,6 +12803,11 @@
       "bin": {
         "tree-kill": "cli.js"
       }
+    },
+    "node_modules/ts-sc-client": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/ts-sc-client/-/ts-sc-client-0.4.0.tgz",
+      "integrity": "sha512-6bfu1mbdjOVN2j2vg7j2i21SnNwy+P7UViT9uAGHLNh9ZYWzkUatTa0ET+RPLGE6k5lPqUwUL4su0nNcTY8KEw=="
     },
     "node_modules/tslib": {
       "version": "2.6.2",

--- a/scn-redactor/package.json
+++ b/scn-redactor/package.json
@@ -22,7 +22,8 @@
     "@angular/router": "^16.2.12",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "zone.js": "~0.13.3"
+    "zone.js": "~0.13.3",
+    "ts-sc-client": "^0.4.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^16.2.10",

--- a/scn-redactor/src/environments/environment.development.ts
+++ b/scn-redactor/src/environments/environment.development.ts
@@ -1,0 +1,3 @@
+export const environment = {
+    webSocketAddress: "ws://localhost:8090/sc-server/ws_json"
+};


### PR DESCRIPTION
These changes will allow you to use agents written for the `sc-machine`. Those can add and remove elements from SCn pages and add and delete SCn pages. I've also written a simple iterator for the page elements, it should be enough for a starting point (since every element that has to be shown "belongs" to the scn_page structure). 

Next, we should determine the types of the elements and fetch human-readable identifiers for nodes that have them. More work and discussions has to be done on how to visualize these results, but this PR would at least allow us to work on real data. Feel free to ask any questions 👀

Code quality is average at best, I've been in a hurry (and raised several issues in sc-machine and ts-sc-client along the way 🤡)

See https://github.com/VasKho/scn-editor/pull/1 and [scn-editor](https://github.com/VasKho/scn-editor) for more info about the agents.

Here's a snippet that I've used for initial tests:
```typescript
  public async test() {
    const action = new Action(
      'action_search_semantic_neighborhood',
      this.scClientService
    );

    const ui_component = await this.scClientService.searchAddrById(
      'concept_user_interface_component'
    );

    if (!ui_component) {
      console.log("couldn't find the concept_user_interface_component");
      return;
    }
    await action.addArgs(ui_component!);
    action.initiate().then((addr) => {
      console.log('done');
      console.log(addr);
    });

    const action2 = new Action('open_scn_page', this.scClientService);
    await action.addArgs(ui_component);
    const pageAddr = await action.initiate();

    console.log('done');
    console.log(await this.scClientService.getPageContents(pageAddr!));
  }
```
